### PR TITLE
Adresss Grafana Feedback

### DIFF
--- a/dashboards/FrequencyOverview.json
+++ b/dashboards/FrequencyOverview.json
@@ -1,0 +1,446 @@
+{
+    "annotations": {
+      "list": []
+    },
+    "editable": true,
+    "fiscalYearStartMonth": 0,
+    "graphTooltip": 0,
+    "id": 4,
+    "links": [],
+    "liveNow": false,
+    "panels": [
+      {
+        "datasource": {
+          "type": "gridprotectionalliance-openhistorian-datasource"
+        },
+        "description": "",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "custom": {
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              }
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "dark-blue",
+                  "value": null
+                },
+                {
+                  "color": "dark-green",
+                  "value": 59.95
+                },
+                {
+                  "color": "dark-red",
+                  "value": 60.05
+                }
+              ]
+            }
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 13,
+          "w": 13,
+          "x": 0,
+          "y": 0
+        },
+        "id": 4,
+        "options": {
+          "basemap": {
+            "config": {},
+            "name": "Base Map",
+            "type": "default"
+          },
+          "controls": {
+            "mouseWheelZoom": true,
+            "showAttribution": true,
+            "showDebug": false,
+            "showMeasure": false,
+            "showScale": false,
+            "showZoom": true
+          },
+          "layers": [
+            {
+              "config": {
+                "showLegend": true,
+                "style": {
+                  "color": {
+                    "field": "Value",
+                    "fixed": "dark-green"
+                  },
+                  "opacity": 0.4,
+                  "rotation": {
+                    "fixed": 0,
+                    "max": 360,
+                    "min": -360,
+                    "mode": "mod"
+                  },
+                  "size": {
+                    "fixed": 5,
+                    "max": 15,
+                    "min": 2
+                  },
+                  "symbol": {
+                    "fixed": "img/icons/marker/circle.svg",
+                    "mode": "fixed"
+                  },
+                  "textConfig": {
+                    "fontSize": 12,
+                    "offsetX": 0,
+                    "offsetY": 0,
+                    "textAlign": "center",
+                    "textBaseline": "middle"
+                  }
+                }
+              },
+              "location": {
+                "mode": "auto"
+              },
+              "name": "Frequency",
+              "tooltip": true,
+              "type": "markers"
+            }
+          ],
+          "tooltip": {
+            "mode": "details"
+          },
+          "view": {
+            "allLayers": true,
+            "id": "north-america",
+            "lat": 40,
+            "lon": -100,
+            "zoom": 4
+          }
+        },
+        "pluginVersion": "9.5.1",
+        "targets": [
+          {
+            "datasource": {
+              "type": "gridprotectionalliance-openhistorian-datasource"
+            },
+            "metadataOptions": [
+              {
+                "FieldName": "Longitude",
+                "Table": "ActiveMeasurements",
+                "Type": "Decimal"
+              },
+              {
+                "FieldName": "Latitude",
+                "Table": "ActiveMeasurements",
+                "Type": "Decimal"
+              }
+            ],
+            "parsedQuery": {
+              "Elements": [],
+              "Filters": [],
+              "Functions": [
+                {
+                  "Function": "Average",
+                  "Parameters": [
+                    {
+                      "type": {
+                        "default": "",
+                        "description": "Target expression that produces a series of values representing input data for the function.",
+                        "name": "expression",
+                        "required": true,
+                        "type": "IAsyncEnumerable<IDataSourceValueType>"
+                      },
+                      "value": {
+                        "Elements": [],
+                        "Filters": [
+                          {
+                            "Condition": "SignalType = 'FREQ'",
+                            "Number": 10,
+                            "NumberMode": "",
+                            "Table": "ActiveMeasurements"
+                          }
+                        ],
+                        "Functions": []
+                      }
+                    }
+                  ]
+                }
+              ]
+            },
+            "refId": "A",
+            "transpose": true
+          }
+        ],
+        "type": "geomap"
+      },
+      {
+        "datasource": {
+          "type": "gridprotectionalliance-openhistorian-datasource"
+        },
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "decimals": 3,
+            "mappings": [],
+            "max": 60.05,
+            "min": 59.95,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "dark-blue",
+                  "value": null
+                },
+                {
+                  "color": "dark-green",
+                  "value": 59.98
+                },
+                {
+                  "color": "dark-red",
+                  "value": 60.02
+                }
+              ]
+            },
+            "unit": "Hz"
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 13,
+          "w": 11,
+          "x": 13,
+          "y": 0
+        },
+        "id": 3,
+        "options": {
+          "orientation": "auto",
+          "reduceOptions": {
+            "calcs": [
+              "mean"
+            ],
+            "fields": "",
+            "values": false
+          },
+          "showThresholdLabels": false,
+          "showThresholdMarkers": true
+        },
+        "pluginVersion": "9.5.1",
+        "targets": [
+          {
+            "datasource": {
+              "type": "openHistorian"
+            },
+           "parsedQuery": {
+            "Elements": [],
+            "Filters": [],
+            "Functions": [
+              {
+                "Function": "SetAverage",
+                "Parameters": [
+                  {
+                    "type": {
+                      "default": "",
+                      "description": "Target expression that produces a series of values representing input data for the function.",
+                      "name": "expression",
+                      "required": true,
+                      "type": "IAsyncEnumerable<IDataSourceValueType>"
+                    },
+                    "value": {
+                      "Elements": [],
+                      "Filters": [],
+                      "Functions": [
+                        {
+                          "Function": "IncludeRange",
+                          "Parameters": [
+                            {
+                              "type": {
+                                "default": "0",
+                                "description": "A floating point value representing the low end of the range allowed in the return series.",
+                                "name": "low",
+                                "required": true,
+                                "type": "Double"
+                              },
+                              "value": "59"
+                            },
+                            {
+                              "type": {
+                                "default": "0",
+                                "description": "A floating point value representing the high end of the range allowed in the return series.",
+                                "name": "high",
+                                "required": true,
+                                "type": "Double"
+                              },
+                              "value": "61"
+                            },
+                            {
+                              "type": {
+                                "default": "False",
+                                "description": "A boolean flag which determines if low value is inclusive.",
+                                "name": "lowInclusive",
+                                "required": false,
+                                "type": "Boolean"
+                              },
+                              "value": "False"
+                            },
+                            {
+                              "type": {
+                                "default": "False",
+                                "description": "A boolean flag which determines if high value is inclusive.",
+                                "name": "highInclusive",
+                                "required": false,
+                                "type": "Boolean"
+                              },
+                              "value": "False"
+                            },
+                            {
+                              "type": {
+                                "default": "",
+                                "description": "Target expression that produces a series of values representing input data for the function.",
+                                "name": "expression",
+                                "required": true,
+                                "type": "IAsyncEnumerable<IDataSourceValueType>"
+                              },
+                              "value": {
+                                "Elements": [],
+                                "Filters": [
+                                  {
+                                    "Condition": "SignalType='FREQ'",
+                                    "Number": 10,
+                                    "NumberMode": "",
+                                    "Table": "ActiveMeasurements"
+                                  }
+                                ],
+                                "Functions": []
+                              }
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+            "queryText": "SetAverage(IncludeRange(59, 61, FILTER ActiveMeasurements WHERE SignalType='FREQ'))",
+            "queryType": "Elements",
+            "refId": "A"
+          }
+        ],
+        "type": "gauge"
+      },
+      {
+        "datasource": {
+          "type": "gridprotectionalliance-openhistorian-datasource"
+        },
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "axisCenteredZero": false,
+              "axisColorMode": "text",
+              "axisLabel": "",
+              "axisPlacement": "auto",
+              "barAlignment": 0,
+              "drawStyle": "line",
+              "fillOpacity": 0,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "lineInterpolation": "linear",
+              "lineWidth": 1,
+              "pointSize": 5,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "showPoints": "auto",
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "none"
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            }
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 8,
+          "w": 24,
+          "x": 0,
+          "y": 13
+        },
+        "id": 2,
+        "options": {
+          "legend": {
+            "calcs": [],
+            "displayMode": "list",
+            "placement": "bottom",
+            "showLegend": true
+          },
+          "tooltip": {
+            "mode": "single",
+            "sort": "none"
+          }
+        },
+        "pluginVersion": "9.5.1",
+        "targets": [
+          {
+            "datasource": {
+             "type": "gridprotectionalliance-openhistorian-datasource"
+            },
+            "queryText": "LABEL('Average Frequency',SliceAvg(0.75, IncludeRange(59, 61, FILTER ActiveMeasurements WHERE SignalType='FREQ')))",
+            "queryType": "Text",
+            "refId": "A"
+          }
+        ],
+        "title": "Average System",
+        "transformations": [],
+        "type": "timeseries"
+      }
+    ],
+    "refresh": "5s",
+    "schemaVersion": 1,
+    "style": "dark",
+    "tags": [],
+    "templating": {
+      "list": []
+    },
+    "time": {
+      "from": "now-5m",
+      "to": "now"
+    },
+    "timepicker": {},
+    "timezone": "",
+    "title": "Frequency Overview",
+    "uid": "f419c525-ac75-4b6e-918e-7e9237ed2535",
+    "version": 7,
+    "weekStart": ""
+  }

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -12,6 +12,7 @@ services:
     volumes:
       - ./dist:/var/lib/grafana/plugins/gpa-openhistorian-datasource
       - ./provisioning:/etc/grafana/provisioning
+      - ./dashboards:/var/lib/grafana/dashboards
       
   openhistorian:
     container_name: openhistorian

--- a/provisioning/dashboards/gpa-openHistorian.yaml
+++ b/provisioning/dashboards/gpa-openHistorian.yaml
@@ -1,0 +1,27 @@
+# Configuration file version
+apiVersion: 1
+
+# List of data sources to insert/update depending on what's
+# available in the database.
+providers:
+ # <string> an unique provider name. Required
+  - name: 'gpa'
+    # <int> Org id. Default to 1
+    orgId: 1
+    # <string> name of the dashboard folder.
+    folder: ''
+    # <string> folder UID. will be automatically generated if not specified
+    folderUid: ''
+    # <string> provider type. Default to 'file'
+    type: file
+    # <bool> disable dashboard deletion
+    disableDeletion: false
+    # <int> how often Grafana will scan for changed dashboards
+    updateIntervalSeconds: 10
+    # <bool> allow updating provisioned dashboards from the UI
+    allowUiUpdates: false
+    options:
+      # <string, required> path to dashboard files on disk. Required when using the 'file' type
+      path: /var/lib/grafana/dashboards
+      # <bool> use folder names from filesystem to create folders in Grafana
+      foldersFromFilesStructure: true

--- a/src/components/ConfigEditor.tsx
+++ b/src/components/ConfigEditor.tsx
@@ -64,7 +64,6 @@ export function ConfigEditor(props: Props) {
   const onHttpChange = (config: DataSourceSettings<OpenHistorianDataSourceOptions>) => {
     if (url.length === 0 && isInitialAssignment) {
       setIsInitialAssignment(false);
-      config.url = '../api/grafana'; // Set the default URL
     }
 
     onOptionsChange(config);

--- a/src/components/ConfigEditor.tsx
+++ b/src/components/ConfigEditor.tsx
@@ -21,13 +21,14 @@ interface Props
 
 export function ConfigEditor(props: Props) {
   const { onOptionsChange, options } = props;
-  const [dataSourceTypes, setDataSourceTypes] = React.useState<DataSourceValueType[]>([])
+  const [dataSourceTypes, setDataSourceTypes] = React.useState<DataSourceValueType[]>(defaultDataSourceTypes)
   const dataSourceTypeOptions = React.useMemo(() => dataSourceTypes.map(s => ({ value: s.index.toString(), label: s.name })), [dataSourceTypes]);
   const url = React.useMemo(() => (options.url ?? ''), [options])
   const [isInitialAssignment, setIsInitialAssignment] = React.useState(true);
 
   React.useEffect(() => {
     if (url.length === 0) {
+      setDataSourceTypes(defaultDataSourceTypes);
       return;
     }
 

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -50,7 +50,7 @@ export class DataSource extends DataSourceApi<OpenHistorianQuery, OpenHistorianD
     this.flags = instanceSettings.jsonData.flags || {};
     this.valueTypeIndex = parseInt(instanceSettings.jsonData.valueTypeIndex || "0", 10);
     this.valueTypeName = instanceSettings.jsonData.valueTypeName || "";
-    this.timeSeriesDefinitions = instanceSettings.jsonData.timeSeriesDefinitions ?? [''];
+    this.timeSeriesDefinitions = instanceSettings.jsonData.timeSeriesDefinitions ?? ['Value', 'Time'];
     this.metadataTableName = instanceSettings.jsonData.metadataTableName || "";
   }
 
@@ -199,7 +199,7 @@ export class DataSource extends DataSourceApi<OpenHistorianQuery, OpenHistorianD
     const hasAnnotationQuery = options.targets.some(t => t.queryType === 'Annotations');;
 
     let data: Array<(MutableDataFrame<any> | undefined)> = [];
-    let error: DataQueryError = {};
+    let error: DataQueryError|undefined = undefined;
     let syntaxErrors: string[] = [];
 
     // Generate query
@@ -210,10 +210,7 @@ export class DataSource extends DataSourceApi<OpenHistorianQuery, OpenHistorianD
       let pointsData: QueryResponse[] = await getBackendSrv().post(this.url + "/query", query);
 
       const tags = this.timeSeriesDefinitions;
-
       const transposeFrames = new Map<string,(MutableDataFrame<any>|undefined)>();
-
-   
 
       // Add metadata fields
       const frames = pointsData.map((d) => {

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -44,6 +44,9 @@ export class DataSource extends DataSourceApi<OpenHistorianQuery, OpenHistorianD
       QueryEditor: AnnotationEditor
     }
     this.url = instanceSettings.url || "";
+    if (this.url.length == 0) {
+      this.url = '../api/grafana';
+    }
     this.flags = instanceSettings.jsonData.flags || {};
     this.valueTypeIndex = parseInt(instanceSettings.jsonData.valueTypeIndex || "0", 10);
     this.valueTypeName = instanceSettings.jsonData.valueTypeName || "";


### PR DESCRIPTION
# Grafana Feedback Addressed 

- If possible, please upload any example dashboards you use to the plugin repository as that will also help us in testing the plugin over time.
- The Data Source Type field on the Config page can be a bit confusing when you first land to create a new connection since it will just spin indefinitely (see image below). I wonder if this field is more appropriate at query time IE the choice to be available to the user from the Query Editor. If not, I think having the default Data Source Type field resolved on the Config page should improve the experience.
- After entering a keystroke when editing the datasource URL field, it is automatically set to ../api/grafana . I think this should just be a placeholder, not actually setting the value.

# Docker Repository
The openHistorian Docker container has been published - no need to download the openHistorian repository for anything

# Other Fixes
The Explore screen no longer shows an empty error message when the query is working