### PR TITLE
Add provenance attestation to automated plugin build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,16 +7,20 @@ on:
     tags:
       - 'v*' # Run workflow on version tags, e.g. v1.0.0.
 
-permissions:
-  contents: write
-
 jobs:
   release:
+    permissions:
+      id-token: write
+      contents: write
+      attestations: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: grafana/plugin-actions/build-plugin@release
-        # (For more info on how to generate the access policy token see https://grafana.com/developers/plugin-tools/publish-a-plugin/sign-a-plugin#generate-an-access-policy-token)
+
+      - uses: grafana/plugin-actions/build-plugin@main
         with:
-          # Make sure to save the token in your repository secrets
+          # see https://grafana.com/developers/plugin-tools/publish-a-plugin/sign-a-plugin#generate-an-access-policy-token to generate it
+          # save the value in your repository secrets
           policy_token: ${{ secrets.GRAFANA_ACCESS_POLICY_TOKEN }}
+          # creates a signed build provenance attestation to verify the authenticity of the plugin build
+          attestation: true


### PR DESCRIPTION
Adds provenance attestation to automated plugin build per Grafana review suggestion.
See https://grafana.com/developers/plugin-tools/publish-a-plugin/build-automation#enable-provenance-attestation for info.